### PR TITLE
Update in default locatie Visual Studio 2022

### DIFF
--- a/docs/process/infoInleverenProgrammas.md
+++ b/docs/process/infoInleverenProgrammas.md
@@ -4,7 +4,7 @@ Als je gemaakte `Visual Studio solutions` wil inleveren in Canvas,
 hou dan rekening met het volgende:
 - Laat `Visual Studio`  tijdens het programmeren alle files opslaan op de door `Visual Studio` voorgestelde plek. (ga dus *niet* losse `files` met behulp van `save as` op andere plekken opslaan).
 - Het gevolg hiervan is dat alle files van een `solution` in 1 `directory` bij elkaar staan.
-- De `default` plek waar `Visual Studio` solutions opslaat is `Documents|Visual Studio(+versienummer)|Projects`.
+- De `default` plek waar `Visual Studio` solutions opslaat is `C:\Users\<je user naam>\source`.
 - Als je 1 `solution` wilt inleveren kun je de directory van die solution `zippen` door in het *rechtermuisknop* van de `directory`  `send to|Compressed (zipped) Folder` te kiezen.
 - Als je meerdere `solutions` in 1 zip wilt inleveren kun je er meerdere selecteren (met `ctrl` of `shift` ingedrukt en dan de `directories` aan te klikken), ook weer met hetzelfde *rechtermuismenu* te zippen.
 - Gebruik in Canvas de `Submit`-button om de zip in te leveren.


### PR DESCRIPTION
Solutions staan tegenwoordig in een andere locatie by default. Zie https://learn.microsoft.com/en-us/visualstudio/ide/solutions-and-projects-in-visual-studio?view=vs-2022#create-new-projects voor meer informatie